### PR TITLE
Validate duplicate page names on rename

### DIFF
--- a/src/routes/page/[id]/update.ts
+++ b/src/routes/page/[id]/update.ts
@@ -3,9 +3,10 @@ import type { Request, Response } from 'express';
 import { authenticateRequest } from '@/middleware/authenticate-request';
 import { validateSchema } from '@/middleware/validate-schema';
 import prisma from '@/resources/prisma';
+import slugify from '@/utils/slugify';
 
 const schema = z.object({
-	name: z.string().optional()
+	name: z.string().min(1).max(50).optional()
 });
 
 export const POST = [
@@ -13,6 +14,32 @@ export const POST = [
 	validateSchema(schema),
 	async (req: Request, res: Response) => {
 		const body = req.body as z.infer<typeof schema>;
+		const pageId = req.params.id as string;
+
+		// If renaming, make sure no sibling page in the same project(s) already
+		// uses that name (mirrors the duplicate check in page/create).
+		if (body.name) {
+			const links = await prisma.tilePageInProject.findMany({
+				where: {
+					tilePageId: pageId,
+					project: { userId: req.userId }
+				},
+				select: { projectId: true }
+			});
+
+			const siblings = await prisma.tilePageInProject.findMany({
+				where: {
+					projectId: { in: links.map((l) => l.projectId) },
+					tilePageId: { not: pageId }
+				},
+				include: { tilePage: true }
+			});
+
+			if (siblings.map(({ tilePage }) => slugify(tilePage.name)).includes(slugify(body.name)))
+				return res.json({
+					error: 'A page with that name already exists in the project.'
+				});
+		}
 
 		await prisma.tilePage.update({
 			where: {


### PR DESCRIPTION
## Why

`page/create` rejects a name already used by another page in the project, but `page/[id]/update` (rename) had no equivalent check — so renaming a page onto an existing name silently created two same-named pages.

## What

Mirror the create check in the update route: resolve the page's connected project(s), load the sibling pages, and reject with the same message (`A page with that name already exists in the project.`) if the new slugified name collides. Schema tightened to `min(1).max(50)` to match create.

(Supersedes #7, which auto-closed when its base branch `remove-server-cache` was deleted on merge of #6. Net diff is now just the rename change.)

## Verification

Deployed to api.freespeechaac.com (tsx, no build); service healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)