### PR TITLE
Allow setting a project's home page via update route

### DIFF
--- a/src/routes/project/[id]/update.ts
+++ b/src/routes/project/[id]/update.ts
@@ -8,7 +8,8 @@ const schema = z.object({
 	name: z.string().min(1).max(255).optional(),
 	columns: z.number().min(1).max(60).optional(),
 	rows: z.number().min(1).max(60).optional(),
-	imageUrl: z.string().optional()
+	imageUrl: z.string().optional(),
+	homePageId: z.string().optional()
 });
 
 export const POST = [
@@ -16,6 +17,19 @@ export const POST = [
 	validateSchema(schema),
 	async (req: Request, res: Response) => {
 		const body = req.body as z.infer<typeof schema>;
+
+		// If setting the home page, make sure it's actually a page in this project.
+		if (body.homePageId) {
+			const link = await prisma.tilePageInProject.findFirst({
+				where: {
+					projectId: req.params.id as string,
+					tilePageId: body.homePageId,
+					project: { userId: req.userId }
+				}
+			});
+
+			if (!link) return res.json({ error: 'That page is not part of this project.' });
+		}
 
 		await prisma.project.update({
 			where: {


### PR DESCRIPTION
## Why

The home page is tracked by `project.homePageId`, but there was no API to *change* it — it was only ever set at project creation or backfilled. The client needs to let users pick which page is home.

## What

`POST /project/:id/update` now accepts an optional `homePageId`. When present, it's validated against `tilePageInProject` to confirm the page is actually part of this project (and owned by the requester) before the update; otherwise it returns `{ error: 'That page is not part of this project.' }`.

Pairs with the freespeech client "Set as Home" action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)